### PR TITLE
check handling of .charm files in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,6 +31,16 @@ jobs:
         run: |
           cd kubernetes-extra
           tox -e integration
+      - name: Check handling of .charm files
+        run: |
+          cd kubernetes-extra
+          mv *.charm foo.charm
+          CHARM_PATH=foo.charm tox -e integration
+          ! CHARM_PATH=bar.charm tox -e integration  # Fails because bar.charm doesn't exist.
+          cp foo.charm bar.charm
+          ! tox -e integration  # Fails because there's more than one .charm file.
+          rm *.charm
+          ! tox -e integration  # Fails because there are no .charm files.
 
   integration-machine:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,10 +34,9 @@ jobs:
       - name: Check handling of .charm files
         run: |
           cd kubernetes-extra
-          mv *.charm foo.charm
+          cp *.charm foo.charm
           CHARM_PATH=foo.charm tox -e integration
           ! CHARM_PATH=bar.charm tox -e integration  # Fails because bar.charm doesn't exist.
-          cp foo.charm bar.charm
           ! tox -e integration  # Fails because there's more than one .charm file.
           rm *.charm
           ! tox -e integration  # Fails because there are no .charm files.
@@ -65,3 +64,12 @@ jobs:
         run: |
           cd machine
           tox -e integration
+      - name: Check handling of .charm files
+        run: |
+          cd machine
+          cp *.charm foo.charm
+          CHARM_PATH=foo.charm tox -e integration
+          ! CHARM_PATH=bar.charm tox -e integration  # Fails because bar.charm doesn't exist.
+          ! tox -e integration  # Fails because there's more than one .charm file.
+          rm *.charm
+          ! tox -e integration  # Fails because there are no .charm files.


### PR DESCRIPTION
Per https://github.com/canonical/charmcraft/pull/2430, the Charmcraft profiles support an environment variable called `CHARM_PATH` with `tox -e integration`. This variable specifies the .charm file to deploy. If no .charm file is specified, the integration tests look for a .charm file in the current directory. This PR adds CI checks for this behavior.